### PR TITLE
Add Kottans badges documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,9 @@ Just a centralized place to keep kottans-related stuff/links
   * Frontside - Yellow octocat
   * Backside - Stylised JS-course code
 
+## Other assets
+
+* [badges](badges.md)
+
 * * *
 *\** - product of their time, don't be judgy

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # artifacts
 Just a centralized place to keep kottans-related stuff/links
 
-# Very precious links*
+## Very precious links*
 
 [Octocats](http://programulya.com/octocats/octocats.html) by [@programulya](github.com/programulya)
 [Code for itjam shirts](http://jsbin.com/babaye/1/edit?html,js,output)
 
-# Wear sources
-### JS-course t-shirt/hoody
-* Frontside - Yellow octocat
-* Backside - Stylised JS-course code
+## Wearables sources
+
+* [JS-course t-shirt/hoody](wear_sources/js-course-shirt/)
+  * Frontside - Yellow octocat
+  * Backside - Stylised JS-course code
 
 * * *
-* - product of their time, don't be judgy
+*\** - product of their time, don't be judgy

--- a/badges.md
+++ b/badges.md
@@ -76,6 +76,7 @@ A recognition note from mentor to a student may look as follows
 >
 > Feel free adding it to your course materials. Just insert the following
 > code somewhere at the top of your course `README.md`:
+>
 > `[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)`
 >
 > Congratulations on the skills level-up!
@@ -89,6 +90,7 @@ Here is your achievement badge:
 
 Feel free adding it to your course materials. Just insert the following
 code somewhere at the top of your course `README.md`:
+
 `[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)`
 
 Congratulations on the skills level-up!

--- a/badges.md
+++ b/badges.md
@@ -1,0 +1,143 @@
+# Badges
+
+This paper describes badges associated with
+[Kottans organization](https://github.com/kottans).
+
+Organization members may use any badges described
+to denote their membership and/or attribution
+of projects and repositories to the organization.
+
+Use badge code to embed the badge into project
+documentation.
+
+Other badges can be created and PRed here
+by Kottans organization members only.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Creating variations](#creating-variations)
+- [General purpose badges](#general-purpose-badges)
+- [Students' achievements](#students-achievements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- generated with DocToc https://github.com/thlorenz/doctoc -->
+
+## Creating variations
+
+To create a badge variation feel free to copy either of the badges
+below and adjusting its label part and color as appropriate.
+Refer to [shields.io](https://shields.io/#/) for customization
+guidelines.
+
+Consider adding variations to this paper in the relevant section.
+
+Each badge should described as a list element containing
+ - look and feel (the badge code per se)
+ - badge code quotation
+ - badge purpose
+
+[_^ TOC ^_](#table-of-contents)
+
+## General purpose badges
+
+ * [![Kottans](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Kottans-lightgrey.svg)](https://github.com/kottans/frontend)
+   `[![Kottans](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Kottans-lightgrey.svg)](https://github.com/kottans/frontend)` -
+   general attribution to Kottans organization
+ * [![Kottans-Frontend](https://img.shields.io/badge/%3D(%5E.%5E)%3D-frontend-yellow.svg)](https://github.com/kottans/frontend)
+   `[![Kottans-Frontend](https://img.shields.io/badge/%3D(%5E.%5E)%3D-frontend-yellow.svg)](https://github.com/kottans/frontend)` -
+   attribution to [kottans/frontend](https://github.com/kottans/frontend) course
+
+
+**Variations**
+
+A variation of the above can be created and used to denote
+e.g. attribution to a particular educational or any other project
+on the top level of Kottans organization.
+
+[_^ TOC ^_](#table-of-contents)
+
+## Students' achievements
+
+Students' achievements badges may be granted by course mentors
+to course students denoting students' valuable achievements.
+
+As Kottans courses provide for tests phase (pre-course, self study phase)
+a collection of badges may help to catch student's skills at a glance
+at admission interviews phase.
+
+A recognition note from mentor to a student may look as follows
+
+Hey! You did a great job worth special recognition.
+
+> Here is your achievement badge:
+> [![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)
+>
+> Feel free adding it to your course materials. Just insert the following
+> code somewhere at the top of your course `README.md`:
+> `[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)`
+>
+> Congratulations on the skills level-up!
+
+Code for the above:
+```
+Hey! You did a great job worth special recognition.
+
+Here is your achievement badge:
+[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)
+
+Feel free adding it to your course materials. Just insert the following
+code somewhere at the top of your course `README.md`:
+`[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)`
+
+Congratulations on the skills level-up!
+```
+
+Use the above as a reference guide.
+
+**Badges**
+
+ * Contributions and PRs
+   - [![Kottans-Student-Contribution-workflow](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20contribution%20workflow-6f42c1.svg)](https://github.com/kottans/)
+     `[![Kottans-Student-Contribution-workflow](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20contribution%20workflow-6f42c1.svg)](https://github.com/kottans/)` -
+     student successfully opened a PR from a feature branch for a complex task and the PR was merged by a mentor
+   - [![Kottans-Student-Conflict-resolution](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20conflict%20resolution-brightgreen.svg)](https://github.com/kottans/)
+     `[![Kottans-Student-Conflict-resolution](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20conflict%20resolution-brightgreen.svg)](https://github.com/kottans/)` -
+     student successfully opened a PR from a feature branch for a complex task and PR was merged by a mentor
+  * Course progress
+    - [![Kottans-Student-Course-progress-5](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--5%20performer-green.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Course-progress-5](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--5%20performer-green.svg)](https://github.com/kottans/frontend)` -
+      student has completed frontend pre-course among first five finishers
+    - [![Kottans-Student-Course-progress-10](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--10%20performer-green.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Course-progress-10](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--10%20performer-green.svg)](https://github.com/kottans/frontend)` -
+      student has completed frontend pre-course among finishers 6..10
+    - [![Kottans-Student-Course-progress-20](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--20%20performer-green.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Course-progress-10](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Top--20%20performer-green.svg)](https://github.com/kottans/frontend)` -
+      student has completed frontend pre-course among finishers 11..20
+    - [![Kottans-Student-Course-progress-grinder](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Course%20grinder-green.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Course-progress-grinder](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Course%20grinder-green.svg)](https://github.com/kottans/frontend)` -
+      student has completed frontend pre-course including optional tasks and readings
+  * Soft skills
+    - [![Kottans-Student-Soft-skills-Knowledge-thirst](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Knowledge%20thirsty-548ebc.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Soft-skills-Knowledge-thirst](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Knowledge%20thirsty-548ebc.svg)](https://github.com/kottans/frontend)` -
+      student asks questions improving her or his knowledge
+    - [![Kottans-Student-Soft-skills-supporter](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Classmates%20inspirer-548ebc.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Soft-skills-supporter](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Classmates%20inspirer-548ebc.svg)](https://github.com/kottans/frontend)` -
+      student actively supports other students, junior mentor
+  * Git
+    - [![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)` -
+      student's `git revert` mastery confirmed
+  * GitHub specific
+    - [![Kottans-Student-Github-pages](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20gh--pages-lightgrey.svg)](https://github.com/kottans/frontend)
+      `[![Kottans-Student-Github-pages](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20gh--pages-lightgrey.svg)](https://github.com/kottans/frontend)` -
+      student's GitHub Pages mastery confirmed
+
+**Variations**
+
+A variation of the above can be created and used to denote
+a particular achievement recognition.
+Consider adding re-usable badges to this paper.
+
+[_^ TOC ^_](#table-of-contents)

--- a/badges.md
+++ b/badges.md
@@ -69,8 +69,8 @@ at admission interviews phase.
 
 A recognition note from mentor to a student may look as follows
 
-Hey! You did a great job worth special recognition.
-
+> Hey! You did a great job worth special recognition.
+>
 > Here is your achievement badge:
 > [![Kottans-Student-Git-revert](https://img.shields.io/badge/%3D(%5E.%5E)%3D-mastered%20git%20revert-orange.svg)](https://github.com/kottans/frontend)
 >
@@ -139,5 +139,9 @@ Use the above as a reference guide.
 A variation of the above can be created and used to denote
 a particular achievement recognition.
 Consider adding re-usable badges to this paper.
+
+Try to stick to colors in subsection (e.g. keep all git-related badges
+orange and github-related badges lightgrey, that my help to visually
+group badges per skill-sets.
 
 [_^ TOC ^_](#table-of-contents)


### PR DESCRIPTION
`badges.md` describes Kottans badges
- for general purposes like [![Kottans](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Kottans-lightgrey.svg)](https://github.com/kottans/frontend)
- course specific like [![Kottans-Frontend](https://img.shields.io/badge/%3D(%5E.%5E)%3D-frontend-yellow.svg)](https://github.com/kottans/frontend)
- to recognize students' achievements, e.g. [![Kottans-Student-Soft-skills-Knowledge-thirst](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Knowledge%20thirsty-548ebc.svg)](https://github.com/kottans/frontend)

Students' achievements badges serve two major purposes:
- achievements recognition encourages students to learn further
- badges in student's course `README.md` form a student's skills profile that might be helpful during admission interview phase

Please, refer to committed files and [this render](https://github.com/kottans/artifacts/blob/e2e1157ba790aeac54b6f1de875d2ef598a1c418/badges.md) for details.

Suggestions, objections and questions are highly appreciated.

Summoning @AMashoshyna , @suchov , @yevhenorlov , @zonzujiro

P.S. Cann't invite reviewers in this repo.